### PR TITLE
fix: 支持 DSH Desktop 解包依赖路径探测

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,9 +211,10 @@ prompt-inject.md 有内容? ──是──> 注入 systemPrompt section
 按优先级自动定位：
 
 1. `DSH_BASE` 环境变量 → 插件根
-2. `npm prefix -g` / `npm config get prefix` → npm 全局目录
-3. 从全局目录反推 `node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai`
-4. 递归搜索兜底
+2. DSH Desktop → `process.resourcesPath/app.asar.unpacked/node_modules/@deepseek-ai`
+3. `npm prefix -g` / `npm config get prefix` → npm 全局目录
+4. 从全局目录反推 `node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai`
+5. 递归搜索兜底
 
 探测失败提示设置 `DSH_BASE`，不清除、不误伤。
 

--- a/README.zh-CN.md
+++ b/README.zh-CN.md
@@ -206,9 +206,10 @@ prompt-inject.md 有内容? ──是──> 注入 systemPrompt section
 按优先级自动定位：
 
 1. `DSH_BASE` 环境变量 → 插件根
-2. `npm prefix -g` / `npm config get prefix` → npm 全局目录
-3. 从全局目录反推 `node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai`
-4. 递归搜索兜底
+2. DSH Desktop → `process.resourcesPath/app.asar.unpacked/node_modules/@deepseek-ai`
+3. `npm prefix -g` / `npm config get prefix` → npm 全局目录
+4. 从全局目录反推 `node_modules/@deepseek-ai/dsh/node_modules/@deepseek-ai`
+5. 递归搜索兜底
 
 探测失败提示设置 `DSH_BASE`，不清除、不误伤。
 

--- a/lib/core.js
+++ b/lib/core.js
@@ -61,12 +61,37 @@ export function findShimDir() {
   return null;
 }
 
+/**
+ * 定位 DSH Desktop 解包后的 @deepseek-ai 依赖目录。
+ * Electron 将 app.asar 中标记为 unpacked 的文件放在相邻目录，补丁应写入该真实路径。
+ */
+function findDesktopAiBase() {
+  const candidates = [];
+  if (typeof process.resourcesPath === "string" && process.resourcesPath.trim()) {
+    candidates.push(path.join(process.resourcesPath, "app.asar.unpacked", "node_modules", "@deepseek-ai"));
+  }
+
+  // ELECTRON_RUN_AS_NODE 模式没有稳定的 resourcesPath，按可执行文件位置回推 Contents/Resources。
+  const contentsDir = path.dirname(path.dirname(process.execPath));
+  candidates.push(path.join(contentsDir, "Resources", "app.asar.unpacked", "node_modules", "@deepseek-ai"));
+
+  for (const candidate of candidates) {
+    if (fs.existsSync(path.join(candidate, "dsh-agent-instructions", "lib"))) {
+      return path.normalize(candidate);
+    }
+  }
+  return null;
+}
+
 export function findAiBase() {
   const env = process.env.DSH_BASE;
   if (env && env.trim()) {
     const p = path.normalize(env.trim());
     if (fs.existsSync(path.join(p, "dsh-agent-instructions", "lib"))) return p;
   }
+
+  const desktopBase = findDesktopAiBase();
+  if (desktopBase) return desktopBase;
 
   const rel = path.join("node_modules", "@deepseek-ai", "dsh", "node_modules", "@deepseek-ai");
 

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
   "bin": {
     "dsh-purge": "bin/dsh-purge.js"
   },
+  "scripts": {
+    "test": "node --test"
+  },
   "files": [
     "lib",
     "bin",

--- a/test/find-ai-base.test.js
+++ b/test/find-ai-base.test.js
@@ -1,0 +1,30 @@
+import assert from "node:assert/strict";
+import { promises as fsp } from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import test from "node:test";
+
+import { findAiBase } from "../lib/core.js";
+
+test("findAiBase detects Electron app.asar.unpacked dependencies", async (t) => {
+  const resourcesPath = await fsp.mkdtemp(path.join(os.tmpdir(), "dsh-purge-desktop-"));
+  const aiBase = path.join(resourcesPath, "app.asar.unpacked", "node_modules", "@deepseek-ai");
+  await fsp.mkdir(path.join(aiBase, "dsh-agent-instructions", "lib"), { recursive: true });
+
+  const originalDescriptor = Object.getOwnPropertyDescriptor(process, "resourcesPath");
+  const originalDshBase = process.env.DSH_BASE;
+
+  // 模拟 Electron 主进程暴露的 resourcesPath。
+  Object.defineProperty(process, "resourcesPath", { configurable: true, value: resourcesPath });
+  delete process.env.DSH_BASE;
+
+  t.after(async () => {
+    if (originalDescriptor) Object.defineProperty(process, "resourcesPath", originalDescriptor);
+    else delete process.resourcesPath;
+    if (originalDshBase === undefined) delete process.env.DSH_BASE;
+    else process.env.DSH_BASE = originalDshBase;
+    await fsp.rm(resourcesPath, { recursive: true, force: true });
+  });
+
+  assert.equal(findAiBase(), aiBase);
+});


### PR DESCRIPTION
## 问题

DSH Desktop 的 Electron 构建会把 `@deepseek-ai` 依赖放在：

```text
process.resourcesPath/app.asar.unpacked/node_modules/@deepseek-ai
```

现有路径探测只覆盖 `DSH_BASE`、全局 npm 安装目录和递归搜索。插件运行在 DSH Desktop 时因此得到 `ai_base=null`，规则设定页显示 `0/8`，8 个补丁均未进入状态检测与应用流程。

## 修改

- 新增 DSH Desktop `app.asar.unpacked` 路径探测。
- Electron 主进程优先使用 `process.resourcesPath`。
- `ELECTRON_RUN_AS_NODE` 场景通过 `process.execPath` 回推 `Contents/Resources`。
- 保持显式 `DSH_BASE` 的最高优先级。
- 保留原有 npm 全局目录和递归搜索兜底。
- 补充 Node 内置测试与中英文路径探测文档。

## 验证

### 自动测试

```text
npm test
✔ findAiBase detects Electron app.asar.unpacked dependencies
ℹ pass 1
ℹ fail 0
```

### 实机验证

环境：macOS、DSH Desktop 2.0.2、Electron 43.4.0。

```json
{
  "ai_base": "/Applications/DSH Desktop.app/Contents/Resources/app.asar.unpacked/node_modules/@deepseek-ai",
  "patches_applied": 8,
  "patches_pending": 0,
  "patches_total": 8,
  "patch_status": {
    "1": "applied",
    "2": "applied",
    "3": "applied",
    "4": "applied",
    "5": "applied",
    "6": "applied",
    "7": "applied",
    "8": "applied"
  }
}
```

规则设定页最终显示 `8/8 已清除`，5 个目标文件均生成 `.dshpurge.bak` 备份。
