### PR TITLE
fix: 修复 Linux/macOS 下 dsh 启动报 SyntaxError 的 bug — shim 按启动器形态注入

### DIFF
--- a/lib/core.js
+++ b/lib/core.js
@@ -1524,8 +1524,52 @@ function isTextShim(fp) {
   }
 }
 
-function shimInjectFor(fname) {
-  if (fname === "dsh.cmd") {
+function nodeShimInject() {
+  return {
+    kind: "node",
+    text:
+      "// dsh-purge shim begin\n" +
+      "process.env.DSH_PERMISSION_MODE = \"danger-full-access\";\n" +
+      "if (!process.env.DSH_HOME && typeof process.getBuiltinModule === \"function\") {\n" +
+      "  try {\n" +
+      "    const _dshShimFs = process.getBuiltinModule(\"node:fs\");\n" +
+      "    const _dshShimArgv = process.argv[1] || \"\";\n" +
+      "    const _dshShimDir = _dshShimArgv.replace(/\\\\/g, \"/\").replace(/\\/[^/]*$/, \"\");\n" +
+      "    for (const _dshShimRel of [\"\", \"/..\", \"/../..\"]) {\n" +
+      "      const _dshShimCand = _dshShimDir + _dshShimRel + \"/.dsh\";\n" +
+      "      try {\n" +
+      "        if (_dshShimFs.statSync(_dshShimCand).isDirectory()) { process.env.DSH_HOME = _dshShimCand; break; }\n" +
+      "      } catch {}\n" +
+      "    }\n" +
+      "  } catch {}\n" +
+      "}\n" +
+      "// dsh-purge shim end\n",
+  };
+}
+
+/**
+ * 判定启动器形态：cmd 批处理 / ps1（含 pwsh shebang）/ node 启动器（ESM/CJS 均兼容）/ 其余按 sh。
+ * 修复：Linux/macOS 的 `dsh` 常是 → lib/bin.js 的符号链接（#!/usr/bin/env node），
+ * 若按 shell 注入 `#` 注释 + export 会让 ESM 直接 SyntaxError。
+ */
+function shimKindOf(fp) {
+  const base = path.basename(fp).toLowerCase();
+  if (base === "dsh.cmd" || base.endsWith(".cmd")) return "cmd";
+  if (base === "dsh.ps1" || base.endsWith(".ps1")) return "ps1";
+  if (/\.(m?js|cjs|mts|cts)$/i.test(base)) return "node";
+  let firstLine = "";
+  try {
+    firstLine = (fs.readFileSync(fp, "utf8").split(/\r?\n/, 1)[0] || "").trim();
+  } catch {}
+  if (firstLine.startsWith("#!")) {
+    if (/\bnode(js)?\b/i.test(firstLine)) return "node";
+    if (/\b(pwsh|powershell)\b/i.test(firstLine)) return "ps1";
+  }
+  return "sh";
+}
+
+function shimInjectFor(kind) {
+  if (kind === "cmd") {
     return {
       kind: "cmd",
       text:
@@ -1536,7 +1580,7 @@ function shimInjectFor(fname) {
         "REM dsh-purge shim end\n",
     };
   }
-  if (fname === "dsh.ps1") {
+  if (kind === "ps1") {
     return {
       kind: "ps1",
       text:
@@ -1552,6 +1596,7 @@ function shimInjectFor(fname) {
         "# dsh-purge shim end\n",
     };
   }
+  if (kind === "node") return nodeShimInject();
   return {
     kind: "sh",
     text:
@@ -1654,7 +1699,7 @@ export async function patchShim(shimDir) {
       } catch {}
     }
     try {
-      await saveText(fp, insertShimInject(text, shimInjectFor(fname)));
+      await saveText(fp, insertShimInject(text, shimInjectFor(shimKindOf(fp))));
       result[fname] = "patched";
     } catch (e) {
       result[fname] = `error:${e}`;


### PR DESCRIPTION
### 问题

Linux/macOS 上 `dsh` 常为 npm 全局安装的符号链接，指向 ESM 入口 `lib/bin.js`。旧实现把启动器一律按 shell 脚本处理，注入 `#` 注释 + `export` 风格的 shim，导致 ESM 解析直接报 `SyntaxError: Invalid or unexpected token`，`dsh` 无法启动（Windows 的 `dsh.cmd` 是批处理文件所以不受影响）。

### 修复

shim 注入改为按启动器**实际形态**区分：

- `dsh.cmd` → 批处理（REM/SET）
- `dsh.ps1` → PowerShell（含 pwsh shebang）
- Node 启动器（`#!/usr/bin/env node` 的 .js/.mjs/.cjs，典型为符号链接 → lib/bin.js）→ `//` 注释 + `process.env`，ESM/CJS 均兼容
- 其余 → shell（`#` + export）

### 验证

- `--apply` 后 `node --check` 通过，`dsh` 正常启动（`--version` 与完整 profile 引导均验证）
- `--revert` 可干净剥离 shim，重复 apply 幂等

改动仅 `lib/core.js`。