### PR TITLE
fix: Electron 宿主(DSH Desktop)跳过 child_process ESM 重定向

### DIFF
--- a/lib/hide-console.js
+++ b/lib/hide-console.js
@@ -73,6 +73,12 @@ function facadeUrl() {
 /** Redirect ESM/CJS resolution of child_process to the windowsHide facade. */
 export function installChildProcessImportHook() {
   if (process.platform !== "win32") return { ok: true, skipped: "not_win32" };
+  // DSH Desktop runs on Electron. Electron’s overrideChildProcess patches
+  // child_process by assigning properties (e.g. exec) onto the module object,
+  // which throws on a frozen ESM namespace. Skip the redirect on Electron hosts.
+  if (typeof process.versions !== "undefined" && process.versions.electron) {
+    return { ok: true, skipped: "electron_host" };
+  }
   if (globalThis[HOOK_MARK]) return { ok: true, already: true };
   const target = facadeUrl();
   registerHooks({
@@ -119,7 +125,6 @@ export function hideConsoleEntrySource() {
   // The facade lives beside this file as dsh-purge-child-process-hide.mjs
   // (copied by installHideConsoleIntoBin).
   return `// ${IMPORT_MARK} — auto-installed by dsh-purge; do not edit
-import { registerHooks } from "node:module";
 import { pathToFileURL } from "node:url";
 import { fileURLToPath } from "node:url";
 
@@ -127,7 +132,13 @@ const HOOK_MARK = "__dshPurgeChildProcessHook";
 const MARK = ${JSON.stringify(MARK)};
 const facade = pathToFileURL(fileURLToPath(new URL("./dsh-purge-child-process-hide.mjs", import.meta.url))).href;
 
-if (process.platform === "win32" && !globalThis[HOOK_MARK]) {
+// DSH Desktop (Electron) must NOT redirect child_process to the ESM facade:
+// Electron’s overrideChildProcess assigns e.g. exec onto the module object,
+// and a frozen ESM namespace throws TypeError. Only the safe wrapping below runs.
+const isElectron = typeof process.versions !== "undefined" && !!process.versions.electron;
+
+if (process.platform === "win32" && !isElectron && !globalThis[HOOK_MARK]) {
+  const { registerHooks } = await import("node:module");
   registerHooks({
     resolve(specifier, context, nextResolve) {
       if (specifier === "node:child_process" || specifier === "child_process") {
@@ -139,7 +150,7 @@ if (process.platform === "win32" && !globalThis[HOOK_MARK]) {
   Object.defineProperty(globalThis, HOOK_MARK, { value: true, enumerable: false });
 }
 
-const cp = process.getBuiltinModule("child_process");
+const cp = process.getBuiltinModule ? process.getBuiltinModule("child_process") : null;
 if (process.platform === "win32" && cp && !cp[MARK]) {
   const hide = (options) => {
     if (options == null) return { windowsHide: true };


### PR DESCRIPTION
## 问题

DSH Desktop（Electron 宿主）在 1.3.5 下打开即进恢复模式：

```
TypeError: Cannot assign to property 'exec' of [object Module]
    at overrideChildProcess (node:electron/js2c/node_init:2:17723)
```

根因：Windows 无感路径用 `registerHooks` 把 `child_process` 重定向到 ESM facade（冻结命名空间）；Electron 初始化时 `overrideChildProcess()` 向 `child_process` 写 `exec` 属性 → 冻结对象抛 TypeError → 插件树加载失败。

## 改动（仅 `lib/hide-console.js`）

1. **入口模板 `hideConsoleEntrySource()`**：
   - Electron 宿主（`process.versions.electron`）下跳过 `registerHooks` 重定向，只保留 `getBuiltinModule` 的安全 `windowsHide` 包装（web/CLI 防闪窗完全不受影响）。
   - `registerHooks` 改为 `await import("node:module")` 惰性加载，避免入口自身顶层 `import { registerHooks }` 影响。
   - `getBuiltinModule` 兼容更老 Node（`process.getBuiltinModule ? ... : null`）。
2. **`installChildProcessImportHook()`**：Electron 宿主早退 `{ skipped: "electron_host" }`，防止插件在 Desktop 宿主进程内运行时二次注册重定向。

## 验证

- 纯 Node（win32，Node v24）：入口加载正常，`child_process` 包装 `mark=true`，重定向能力保留。
- 模拟 Electron（设 `process.versions.electron` 后加载入口）：不再注册重定向；执行 `cp.exec = cp.exec`（等价 overrideChildProcess 的写属性）不抛错，包装仍生效。
- 真实环境：DSH Desktop 恢复模式消除，设置页正常；`profiles/web`（CLI）防闪窗正常。

## 说明

- 未包含与本修复无关的本地改动。
- 兼容 1.3.5 与 master；对旧版（无 `registerHooks` 路径，Node <22）无影响。
